### PR TITLE
feat: add project read-more dropdowns

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,10 +1,18 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import { getCollection } from 'astro:content';
+import { getCollection, render } from 'astro:content';
 
-const allProjects = (await getCollection('projects')).sort(
-  (a, b) => a.data.order - b.data.order,
-);
+const allProjects = await Promise.all(
+  (await getCollection('projects')).map(async (project) => {
+    const { Content } = await render(project);
+
+    return {
+      ...project,
+      Content,
+      hasDetails: (project.body ?? '').trim().length > 0,
+    };
+  }),
+).then((projects) => projects.sort((a, b) => a.data.order - b.data.order));
 const personal = allProjects.filter((p) => p.data.category === 'personal');
 const academic = allProjects.filter((p) => p.data.category === 'academic');
 ---
@@ -85,6 +93,14 @@ const academic = allProjects.filter((p) => p.data.category === 'academic');
                 </div>
               </div>
               <p class="type-body mb-4">{project.data.description}</p>
+              {project.hasDetails && (
+                <details class="project-details mb-4">
+                  <summary>read more</summary>
+                  <div class="project-details-content type-prose">
+                    <project.Content />
+                  </div>
+                </details>
+              )}
               <div class="flex flex-wrap gap-1.5">
                 {project.data.tags.map((tag) => (
                   <span class="bg-border px-2 py-0.5 rounded text-[11px] text-muted">
@@ -149,6 +165,14 @@ const academic = allProjects.filter((p) => p.data.category === 'academic');
                 </div>
               </div>
               <p class="type-body mb-4">{project.data.description}</p>
+              {project.hasDetails && (
+                <details class="project-details mb-4">
+                  <summary>read more</summary>
+                  <div class="project-details-content type-prose">
+                    <project.Content />
+                  </div>
+                </details>
+              )}
               <div class="flex flex-wrap gap-1.5">
                 {project.data.tags.map((tag) => (
                   <span class="bg-border px-2 py-0.5 rounded text-[11px] text-muted">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -153,6 +153,27 @@
     @apply text-heading;
   }
 
+  .project-details {
+    @apply rounded-xl border border-border bg-bg/35 px-4 py-3;
+  }
+
+  .project-details > summary {
+    @apply text-dim text-sm font-semibold cursor-pointer select-none transition-colors;
+  }
+
+  .project-details > summary:hover,
+  .project-details[open] > summary {
+    @apply text-heading;
+  }
+
+  .project-details-content {
+    @apply mt-3 border-t border-border pt-3;
+  }
+
+  .project-details-content > :first-child {
+    margin-top: 0;
+  }
+
   @media (min-width: 48rem) {
     .type-hero {
       @apply text-6xl;


### PR DESCRIPTION
## Summary
- Uses native semantic `<details>/<summary>` controls for project card read-more sections.
- Renders each project markdown body inside the dropdown when body content exists.
- Adds matching dark-card styling for the project details panel.

Closes #23.

## Verification
- `corepack pnpm exec prettier --write src/pages/projects.astro src/styles/global.css`
- `corepack pnpm run check` (passes; existing hints remain in `src/pages/people.astro` about `edges`/inline script)
- `corepack pnpm run build`
- Confirmed generated `dist/projects/index.html` contains `<details class="project-details mb-4">` read-more blocks.

Draft PR: awaiting maintainer review and approval before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Project cards now feature expandable "read more" sections to reveal additional details when available.
  * Collapsible sections only display when supplementary content exists, maintaining a clean interface.
  * Enhanced styling for improved visual presentation of expandable project information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->