### PR TITLE
fix: silence people page inline script hints

### DIFF
--- a/src/pages/people.astro
+++ b/src/pages/people.astro
@@ -616,15 +616,16 @@ for (const edge of semanticGraph.semanticEdges) {
 </style>
 
 <script
+  is:inline
   define:vars={{
     people: graphNodes,
-    edges: graphEdges,
+    connections: graphEdges,
     categoryMeta,
     categoryCenters,
   }}
 >
   const nodes = people;
-  const edgeList = edges;
+  const edgeList = connections;
   const nodeEls = Array.from(document.querySelectorAll('[data-node]'));
   const labelEls = Array.from(document.querySelectorAll('[data-label]'));
   const edgeEls = Array.from(


### PR DESCRIPTION
## Summary\n- mark the people graph client script explicitly as inline\n- rename the injected edge data variable to avoid Astro/TypeScript name hint noise\n\n## Validation\n- pnpm run check\n- pnpm run build\n\nNo merge performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated variable references and optimized client-side script handling for improved maintainability on the people page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->