### PR TITLE
docs — clarify environment setup paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ pnpm preview
 pnpm check
 ```
 
-For the chat API or tunnel, copy `.env.example` to `.env` and set `OPENROUTER_API_KEY` and `TUNNEL_TOKEN`.
+Environment setup depends on how you run the chat API:
+
+- For the Docker Compose stack, copy the root `.env.example` to `.env` and set `OPENROUTER_API_KEY`; set `TUNNEL_TOKEN` only when running the Cloudflare tunnel.
+- For standalone API development from `api/`, copy `api/.env.example` to `api/.env` and set the API-local values such as `OPENROUTER_API_KEY`, `CHAT_MODEL`, `CHAT_API_URL`, and `PORT`.
 
 ## Content And Docs
 


### PR DESCRIPTION
## repo-agent validation

Lane: docs
Goal: clarify the two environment setup paths for the portfolio chat API and Docker Compose stack.
Base branch: main
Source: scheduled repo-agent scan; low-touch docs candidate
Risk: low

Changed files:
- `README.md`

Checks run:
- `git diff --check` — pass
- `pnpm exec prettier --check README.md` — pass
- `pnpm run check` — pass

Opus verdict: PASS_OPEN_PR

Known limitations:
- Docs-only change; no runtime behavior changed.

Status: awaiting maintainer review/merge.
