### PR TITLE
ci — disable Jekyll fallback for Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Production runs with Docker Compose:
 
 Jenkins installs dependencies, runs lint/test steps when available, and rebuilds the compose stack from `main` after a push. `pnpm run deploy` is intentionally local-only: it verifies the site with `check` and `build`, then reminds you that Jenkins owns the actual deployment.
 
+GitHub Pages is not the production deployment path for this repo. The root `.nojekyll` marker is present only to prevent GitHub's default Pages/Jekyll fallback from trying to parse Astro source files if branch-based Pages remains enabled in repository settings.
+
 ## License
 
 MIT


### PR DESCRIPTION
## repo-agent validation

Kanban task: repo-agent:pr:portfolio:tbd (kanban CLI unavailable in this run context)
Issue: Fixes #32
Lane: ci
Goal: prevent GitHub Pages default Jekyll fallback from parsing Astro source files while documenting Jenkins as the production deploy path.
Base branch: main
Source: GitHub issue #32
Risk: low

## Changed files
- `.nojekyll`
- `README.md`

## Checks run
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run check` — pass
- `corepack pnpm run build` — pass

## Review
Opus verdict: PASS_OPEN_PR

## Known limitations
This PR prevents Jekyll processing if branch-based GitHub Pages remains enabled. It does not change repository Pages settings; production deployment remains Jenkins as documented.

Status: awaiting maintainer review/merge.