### PR TITLE
Harden cookieless first-party analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Environment setup depends on how you run the chat API:
 
 - Content collections are typed in `src/content.config.ts`.
 - The Chat API HTML and Markdown docs render from `src/data/chatApiDocs.ts`, with endpoint/schema details pulled from `api/openapi.json`.
+- Privacy-first event vocabulary, aggregate queries, dashboard boundaries, and metric caveats are documented in `docs/privacy-first-analytics.md`.
 - Page Markdown variants are available by sending `Accept: text/markdown` or by requesting the explicit `.md` route.
 
 ## Deployment

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
  "woothee",
 ]
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,6 +12,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 rusqlite = { version = "0.37", features = ["bundled"] }
 sha2 = "0.10"
 woothee = "0.13"
+url = "2"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
 dotenvy = "0.15"

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -53,7 +53,7 @@
     "/api/events": {
       "post": {
         "summary": "Record a usage event",
-        "description": "Cookieless first-party analytics ping sent by the site itself (page views, chat opens, game launches, outbound clicks, form submissions, 404s). Stores the path, optional external referrer, optional target, campaign tag, device class, browser/OS family and first Accept-Language tag (parsed server-side, raw user agent never stored), a coarse country code, and a daily-rotating anonymous visitor hash. Never stores raw IPs. Requests carrying DNT: 1 or Sec-GPC: 1 are accepted but not recorded. Rate limited per-IP (60 req/min).",
+        "description": "Cookieless first-party analytics ping sent by the site itself (page views, aggregate internal navigation transitions, chat opens, game launches, outbound clicks, form submissions, 404s). Navigation records only a source path, destination path, and coarse placement; it does not create a browser or session identifier. Stores an optional external referrer origin, optional query-free target, direct/external acquisition classification, normalized campaign source, device class, browser/OS family and first Accept-Language tag (parsed server-side, raw user agent never stored), a coarse country code, and a daily-rotating anonymous visitor hash. Never stores raw IPs. Requests carrying DNT: 1 or Sec-GPC: 1 are accepted but not recorded. Rate limited per-IP (60 req/min).",
         "operationId": "event",
         "requestBody": {
           "required": true,
@@ -141,19 +141,30 @@
         "properties": {
           "kind": {
             "type": "string",
-            "enum": ["pageview", "chat_open", "game_open", "outbound_click", "form_submit", "not_found"]
+            "enum": ["pageview", "chat_open", "game_open", "outbound_click", "navigation", "form_submit", "not_found"]
           },
           "path": { "type": "string", "maxLength": 512, "pattern": "^/" },
-          "referrer": { "type": ["string", "null"], "maxLength": 512 },
+          "referrer": { "type": ["string", "null"], "maxLength": 512, "description": "External origin only; path, query and fragment are discarded server-side." },
           "target": {
             "type": ["string", "null"],
             "maxLength": 512,
-            "description": "What was acted on: destination URL for outbound_click, game id for game_open."
+            "description": "What was acted on: query-free destination origin/path for outbound_click (or email), path-only internal destination for navigation, or game id for game_open."
+          },
+          "placement": {
+            "type": ["string", "null"],
+            "enum": ["header", "footer", "content", "cta", null],
+            "description": "Coarse link placement for navigation and outbound_click."
+          },
+          "attribution": {
+            "type": ["string", "null"],
+            "enum": ["direct", "external", null],
+            "description": "Direct or external acquisition classification on pageviews."
           },
           "source": {
             "type": ["string", "null"],
-            "maxLength": 128,
-            "description": "Campaign tag from the landing URL (utm_source or ref query param)."
+            "maxLength": 64,
+            "pattern": "^[a-z0-9_-]+$",
+            "description": "Normalized campaign tag from the landing URL (utm_source or ref query param)."
           },
           "screen": {
             "type": ["string", "null"],

--- a/api/src/db.rs
+++ b/api/src/db.rs
@@ -40,7 +40,9 @@ CREATE TABLE IF NOT EXISTS events (
     os       TEXT,
     lang     TEXT,
     source   TEXT,
-    screen   TEXT
+    screen   TEXT,
+    placement TEXT,
+    attribution TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);
 CREATE INDEX IF NOT EXISTS idx_events_path ON events(path);
@@ -70,6 +72,8 @@ pub struct EventLog {
     pub lang: Option<String>,
     pub source: Option<String>,
     pub screen: Option<String>,
+    pub placement: Option<String>,
+    pub attribution: Option<String>,
 }
 
 pub enum LogEntry {
@@ -111,8 +115,8 @@ fn insert(conn: &Connection, entry: LogEntry) -> rusqlite::Result<()> {
             conn.execute(
                 "INSERT INTO events
                     (ts, kind, path, referrer, target, visitor, country,
-                     browser, os, lang, source, screen)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                     browser, os, lang, source, screen, placement, attribution)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
                 params![
                     now_unix(),
                     e.kind,
@@ -125,7 +129,9 @@ fn insert(conn: &Connection, entry: LogEntry) -> rusqlite::Result<()> {
                     e.os,
                     e.lang,
                     e.source,
-                    e.screen
+                    e.screen,
+                    e.placement,
+                    e.attribution
                 ],
             )?;
         }
@@ -169,6 +175,21 @@ pub fn spawn_writer(path: String) -> mpsc::UnboundedSender<LogEntry> {
         if let Err(e) = conn.execute_batch(SCHEMA) {
             tracing::error!("failed to create sqlite schema: {e}");
             return;
+        }
+        // CREATE TABLE IF NOT EXISTS does not upgrade existing deployments.
+        for column in ["placement", "attribution"] {
+            let exists = conn
+                .prepare("SELECT 1 FROM pragma_table_info('events') WHERE name = ?1")
+                .and_then(|mut stmt| stmt.exists([column]))
+                .unwrap_or(false);
+            if !exists {
+                if let Err(e) =
+                    conn.execute(&format!("ALTER TABLE events ADD COLUMN {column} TEXT"), [])
+                {
+                    tracing::error!("failed to add events.{column}: {e}");
+                    return;
+                }
+            }
         }
         tracing::info!("sqlite data layer ready at {path}");
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -33,10 +33,13 @@ const EVENT_KINDS: &[&str] = &[
     "chat_open",
     "game_open",
     "outbound_click",
+    "navigation",
     "form_submit",
     "not_found",
 ];
 const SCREEN_CLASSES: &[&str] = &["mobile", "tablet", "desktop"];
+const LINK_PLACEMENTS: &[&str] = &["header", "footer", "content", "cta"];
+const ATTRIBUTION_KINDS: &[&str] = &["direct", "external"];
 const MAX_SOURCE_LEN: usize = 128;
 const MAX_LANG_LEN: usize = 16;
 const DEFAULT_DB_PATH: &str = "portfolio.db";
@@ -358,6 +361,10 @@ fn visitor_hash(salt: &str, ip: &str, ua: &str) -> String {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs() / 86400)
         .unwrap_or(0);
+    visitor_hash_for_day(salt, day, ip, ua)
+}
+
+fn visitor_hash_for_day(salt: &str, day: u64, ip: &str, ua: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(salt.as_bytes());
     hasher.update(day.to_le_bytes());
@@ -369,6 +376,43 @@ fn visitor_hash(salt: &str, ip: &str, ua: &str) -> String {
         .take(8)
         .map(|b| format!("{b:02x}"))
         .collect()
+}
+
+// Minimize client-controlled dimensions again at the storage boundary.
+fn sanitize_url(value: Option<String>, origin_only: bool) -> Option<String> {
+    let raw = value?.trim().to_string();
+    if !origin_only && raw.eq_ignore_ascii_case("email") {
+        return Some("email".to_string());
+    }
+    let parsed = url::Url::parse(&raw).ok()?;
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return None;
+    }
+    let host = parsed.host_str()?;
+    let mut safe = format!("{}://{}", parsed.scheme(), host);
+    if let Some(port) = parsed.port() {
+        safe.push_str(&format!(":{port}"));
+    }
+    if !origin_only {
+        safe.push_str(parsed.path());
+    }
+    (safe.len() <= MAX_EVENT_FIELD_LEN).then_some(safe)
+}
+
+// Keep first-party routes to a path only: never accept query strings/fragments.
+fn sanitize_path(value: String) -> Option<String> {
+    let path = value.split(['?', '#']).next()?.trim();
+    (path.starts_with('/') && path.len() <= MAX_EVENT_FIELD_LEN).then(|| path.to_string())
+}
+
+fn sanitize_source(value: Option<String>) -> Option<String> {
+    let source = value?.trim().to_ascii_lowercase();
+    (!source.is_empty()
+        && source.len() <= 64
+        && source
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'))
+    .then_some(source)
 }
 
 // random per-boot fallback when ANALYTICS_SALT isn't set. unique-visitor
@@ -591,9 +635,15 @@ struct EventRequest {
     path: String,
     #[serde(default)]
     referrer: Option<String>,
-    // what was acted on: destination url for outbound_click, game id for game_open
+    // what was acted on: destination url/path for link events, game id for game_open
     #[serde(default)]
     target: Option<String>,
+    // link surface for navigation and outbound_click
+    #[serde(default)]
+    placement: Option<String>,
+    // direct or external acquisition on pageviews only
+    #[serde(default)]
+    attribution: Option<String>,
     // campaign tag from the landing url: utm_source or ref query param
     #[serde(default)]
     source: Option<String>,
@@ -606,7 +656,7 @@ fn validate_event(req: &EventRequest) -> Result<(), &'static str> {
     if !EVENT_KINDS.contains(&req.kind.as_str()) {
         return Err("unknown event kind");
     }
-    if !req.path.starts_with('/') || req.path.len() > MAX_EVENT_FIELD_LEN {
+    if sanitize_path(req.path.clone()).is_none() {
         return Err("invalid path");
     }
     for field in [&req.referrer, &req.target] {
@@ -626,6 +676,16 @@ fn validate_event(req: &EventRequest) -> Result<(), &'static str> {
             return Err("invalid screen class");
         }
     }
+    if let Some(placement) = &req.placement {
+        if !LINK_PLACEMENTS.contains(&placement.as_str()) {
+            return Err("invalid link placement");
+        }
+    }
+    if let Some(attribution) = &req.attribution {
+        if !ATTRIBUTION_KINDS.contains(&attribution.as_str()) {
+            return Err("invalid attribution");
+        }
+    }
     Ok(())
 }
 
@@ -635,6 +695,10 @@ async fn event_handler(
     headers: HeaderMap,
     Json(payload): Json<EventRequest>,
 ) -> StatusCode {
+    // Opted-out requests should not even enter the per-IP analytics limiter.
+    if opted_out(&headers) {
+        return StatusCode::NO_CONTENT;
+    }
     let ip = client_ip(&headers, &addr);
     if !state.event_rate_limiter.check(&ip) {
         return StatusCode::TOO_MANY_REQUESTS;
@@ -642,24 +706,41 @@ async fn event_handler(
     if validate_event(&payload).is_err() {
         return StatusCode::BAD_REQUEST;
     }
-    if opted_out(&headers) {
-        return StatusCode::NO_CONTENT;
-    }
 
     let ua = user_agent(&headers);
     let (browser, os) = browser_os(ua);
+    let is_outbound = payload.kind == "outbound_click";
+    let is_navigation = payload.kind == "navigation";
+    let is_pageview = payload.kind == "pageview";
+    let referrer = sanitize_url(payload.referrer, true);
+    // Derive this server-side so clients cannot turn a referral into direct traffic.
+    let attribution = is_pageview.then(|| {
+        if referrer.is_some() {
+            "external".to_string()
+        } else {
+            "direct".to_string()
+        }
+    });
     let _ = state.log_tx.send(db::LogEntry::Event(db::EventLog {
         kind: payload.kind,
-        path: payload.path,
-        referrer: payload.referrer.filter(|r| !r.trim().is_empty()),
-        target: payload.target.filter(|t| !t.trim().is_empty()),
+        path: sanitize_path(payload.path).expect("validated path"),
+        referrer,
+        target: if is_outbound {
+            sanitize_url(payload.target, false)
+        } else if is_navigation {
+            payload.target.and_then(sanitize_path)
+        } else {
+            payload.target.filter(|t| !t.trim().is_empty())
+        },
         visitor: visitor_hash(&state.analytics_salt, &ip, ua),
         country: visitor_country(&headers),
         browser,
         os,
         lang: visitor_lang(&headers),
-        source: payload.source.filter(|s| !s.trim().is_empty()),
+        source: sanitize_source(payload.source),
         screen: payload.screen,
+        placement: payload.placement,
+        attribution,
     }));
 
     StatusCode::NO_CONTENT
@@ -811,6 +892,8 @@ mod tests {
             path: path.to_string(),
             referrer: None,
             target: None,
+            placement: None,
+            attribution: None,
             source: None,
             screen: None,
         };
@@ -818,11 +901,21 @@ mod tests {
             screen: Some("4k-ultrawide".to_string()),
             ..event("pageview", "/")
         };
+        let bad_placement = EventRequest {
+            placement: Some("sidebar".to_string()),
+            ..event("navigation", "/blog")
+        };
+        let bad_attribution = EventRequest {
+            attribution: Some("internal".to_string()),
+            ..event("pageview", "/")
+        };
 
-        assert!(validate_event(&event("pageview", "/blog")).is_ok());
+        assert!(validate_event(&event("navigation", "/blog")).is_ok());
         assert!(validate_event(&event("keylogger", "/")).is_err());
         assert!(validate_event(&event("pageview", "https://elsewhere.example")).is_err());
         assert!(validate_event(&bad_screen).is_err());
+        assert!(validate_event(&bad_placement).is_err());
+        assert!(validate_event(&bad_attribution).is_err());
     }
 
     #[test]
@@ -856,5 +949,62 @@ mod tests {
 
         assert_eq!(a.len(), 16);
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn visitor_hash_rotates_daily() {
+        let salt = boot_salt();
+        let a = visitor_hash_for_day(&salt, 10, "203.0.113.7", "Mozilla/5.0");
+        let same = visitor_hash_for_day(&salt, 10, "203.0.113.7", "Mozilla/5.0");
+        let next = visitor_hash_for_day(&salt, 11, "203.0.113.7", "Mozilla/5.0");
+        assert_eq!(a, same);
+        assert_ne!(a, next);
+        assert!(
+            a.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        );
+    }
+
+    #[test]
+    fn privacy_signals_are_honoured() {
+        for name in ["dnt", "sec-gpc"] {
+            let mut headers = HeaderMap::new();
+            headers.insert(name, " 1 ".parse().unwrap());
+            assert!(opted_out(&headers));
+        }
+        assert!(!opted_out(&HeaderMap::new()));
+    }
+
+    #[test]
+    fn analytics_dimensions_are_minimized() {
+        assert_eq!(
+            sanitize_url(
+                Some("https://search.example/results?q=private#x".into()),
+                true
+            ),
+            Some("https://search.example".into())
+        );
+        assert_eq!(
+            sanitize_url(Some("https://example.com/cv?token=secret#x".into()), false),
+            Some("https://example.com/cv".into())
+        );
+        assert_eq!(
+            sanitize_url(Some("mailto:person@example.com".into()), false),
+            None
+        );
+        assert_eq!(
+            sanitize_url(Some("email".into()), false),
+            Some("email".into())
+        );
+        assert_eq!(
+            sanitize_source(Some(" GitHub_2026 ".into())),
+            Some("github_2026".into())
+        );
+        assert_eq!(sanitize_source(Some("person@example.com".into())), None);
+        assert_eq!(
+            sanitize_path("/projects?token=private#section".into()),
+            Some("/projects".into())
+        );
+        assert_eq!(sanitize_path("https://elsewhere.example/path".into()), None);
     }
 }

--- a/docs/privacy-first-analytics.md
+++ b/docs/privacy-first-analytics.md
@@ -1,0 +1,72 @@
+# Privacy-first analytics operations
+
+The portfolio's analytics are intentionally first-party and cookieless. Do not add a browser identifier, cookies, local/session storage, third-party analytics, session replay, or cross-day identity. `DNT: 1` and `Sec-GPC: 1` must remain a client- and server-side opt-out.
+
+## Shared event vocabulary
+
+Native apps can use the same small `object_action` vocabulary when the event answers an operational question:
+
+| Event | Meaning | Optional target |
+| --- | --- | --- |
+| `pageview` | A route was viewed | none |
+| `chat_open` | The assistant UI was opened | none |
+| `game_open` | A game was launched | allowlisted game id |
+| `outbound_click` | A visitor followed an external link | origin + path, without query/fragment; `email` for mail links |
+| `navigation` | An internal link was followed | source path in `path`, destination path in `target`, and header/footer/content/CTA placement |
+| `form_submit` | A contact submission was attempted | none |
+| `not_found` | A missing route was requested | none |
+
+Do not add free-form payloads, content, persistent user/session IDs, scroll tracking, heartbeats, or precise device data. New apps should implement event capture natively against their own first-party endpoint and expose only aggregates centrally. Raw rows stay with the app that collected them.
+
+Acquisition is deliberately coarse: landing path, an `attribution` value of `direct` or `external`, external referrer origin, and a normalized `utm_source` or `ref` containing only lowercase letters, digits, `_`, or `-`. Internal navigation is recorded as independent aggregate source-path → destination-path clicks with a fixed link placement. It does not use a cookie, browser storage, session identifier, or any client-side history.
+
+## Local aggregate queries
+
+The SQLite database is the source of truth. Use a read-only connection or a read-only Metabase/Grafana SQLite data source on the private network; never expose the database or raw event/chat rows publicly.
+
+```sql
+-- daily traffic and approximate daily uniques (do not treat their sum as people)
+SELECT date(ts, 'unixepoch') AS day,
+       count(*) AS pageviews,
+       count(DISTINCT visitor) AS daily_uniques
+FROM events
+WHERE kind = 'pageview' AND ts >= unixepoch('now', '-30 days')
+GROUP BY day ORDER BY day;
+
+-- top landing/content paths
+SELECT path, count(*) AS views
+FROM events
+WHERE kind = 'pageview' AND ts >= unixepoch('now', '-30 days')
+GROUP BY path ORDER BY views DESC LIMIT 20;
+
+-- coarse acquisition; referrer contains origin only
+SELECT coalesce(source, referrer, attribution, 'direct') AS source, count(*) AS views
+FROM events
+WHERE kind = 'pageview' AND ts >= unixepoch('now', '-30 days')
+GROUP BY 1 ORDER BY views DESC LIMIT 20;
+
+-- aggregate internal navigation and link-placement performance
+SELECT path AS from_path, target AS to_path, placement, count(*) AS transitions
+FROM events
+WHERE kind = 'navigation' AND ts >= unixepoch('now', '-30 days')
+GROUP BY from_path, to_path, placement
+ORDER BY transitions DESC LIMIT 20;
+
+-- useful engagement without inspecting chat content
+SELECT kind, count(*) AS events
+FROM events
+WHERE kind <> 'pageview' AND ts >= unixepoch('now', '-30 days')
+GROUP BY kind ORDER BY events DESC;
+
+-- assistant reliability, derived from existing logs (never chart question/reply)
+SELECT status, count(*) AS requests, round(avg(latency_ms)) AS avg_latency_ms
+FROM chat_logs
+WHERE ts >= unixepoch('now', '-30 days')
+GROUP BY status ORDER BY requests DESC;
+```
+
+A central dashboard should contain only these fixed aggregates, use private access control, suppress tiny demographic buckets if added, and never return visitor hashes, conversation IDs, questions, replies, or raw rows. Prefer this read-only setup over adding a public/admin API until multiple consumers justify the extra authentication and maintenance surface.
+
+## Retention and interpretation
+
+Chat rows are pruned after 365 days and event rows after 730 days. Verify infrastructure backup expiry separately because SQL deletion does not remove older snapshots. Visitor hashes rotate at UTC day boundaries, so `count(distinct visitor)` is an approximate daily unique metric only; there is intentionally no cross-day retention or cohort identity.

--- a/src/data/privacy.ts
+++ b/src/data/privacy.ts
@@ -4,7 +4,7 @@ export const privacyMeta = {
   title: 'Privacy',
   pageDescription:
     'What semyon.ie collects and why. No cookies, no banners, no raw IPs.',
-  updated: '10 June 2026',
+  updated: '11 July 2026',
 };
 
 export interface PrivacySection {
@@ -21,10 +21,10 @@ export const privacySections: PrivacySection[] = [
     heading: 'What gets collected',
     items: [
       'Assistant chats: the messages you send, the reply you get, a timestamp, response time, and which model answered. Chats are read later to improve the assistant and to spot what people look for, so please don’t type personal details into it.',
-      'Usage events: page views, chat opens, game launches, outbound link clicks, contact form submissions, and requests for pages that don’t exist, with the page path and, for visits arriving from elsewhere, the referring site and any campaign tag on the link.',
+      'Usage events: page views, aggregate internal navigation between site paths, coarse link placement (header, footer, content, or call to action), chat opens, game launches, outbound link clicks, contact form submissions, and requests for pages that don’t exist. Event URLs are limited to paths or external origins and paths, without query strings or fragments. Page views are classified only as direct or external arrivals; navigation events are not tied together into a browsing history.',
       'Device context per event: browser and operating system family (parsed from the user agent, the raw string is never kept), preferred language, and a coarse device class (mobile, tablet, or desktop).',
       'Rough location: a two-letter country code resolved by Cloudflare at the network edge. This site never looks up or stores your IP address itself.',
-      'An anonymous visitor id: a salted hash of your IP and browser that rotates every day, used to count unique visitors. It can’t be reversed to your IP and can’t link your visits across days.',
+      'An anonymous visitor id: a salted hash of your IP and browser that rotates every day, used to estimate daily unique visitors. It is designed not to reveal your IP and can’t link your visits across days.',
     ],
   },
   {
@@ -32,7 +32,7 @@ export const privacySections: PrivacySection[] = [
     items: [
       'Raw IP addresses. They’re used transiently in memory for rate limiting, then discarded.',
       'Names, emails, or accounts, unless you type them into the chat or the contact form yourself.',
-      'Anything stored on or read from your device.',
+      'Anything stored in or read from browser storage.',
     ],
   },
   {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -87,6 +87,7 @@ const navLinks = [
 
     <!-- nav -->
     <header
+      data-analytics-placement="header"
       class="sticky top-0 z-40 border-b border-border backdrop-blur-md bg-bg/80"
     >
       <div
@@ -181,7 +182,10 @@ const navLinks = [
     </main>
 
     <!-- contact footer -->
-    <footer class="border-t border-border mt-24">
+    <footer
+      data-analytics-placement="footer"
+      class="border-t border-border mt-24"
+    >
       <div class="max-w-6xl mx-auto px-6 py-16">
         <div class="grid md:grid-cols-2 gap-12">
           <div>
@@ -287,20 +291,33 @@ const navLinks = [
     {showChatbot && <Chatbot client:load />}
 
     <script>
-      import { track } from '../lib/track';
+      import {
+        linkPlacement,
+        safeInternalTarget,
+        safeOutboundTarget,
+        track,
+      } from '../lib/track';
       // fires on initial load and after every view-transition navigation
       document.addEventListener('astro:page-load', () => track('pageview'));
 
-      // outbound links, including mailto. delegated so it survives
-      // view transitions, keepalive so it survives the navigation itself
+      // Delegated so it survives view transitions. It records independent
+      // aggregate link actions only; it creates no browser/session state.
       document.addEventListener('click', (e) => {
         const link = (e.target as Element | null)?.closest?.('a[href]');
         if (!(link instanceof HTMLAnchorElement)) return;
         const external =
           (link.protocol === 'http:' || link.protocol === 'https:') &&
           link.origin !== location.origin;
+        const placement = linkPlacement(link);
         if (external || link.protocol === 'mailto:') {
-          track('outbound_click', link.href);
+          const target = safeOutboundTarget(link.href);
+          if (target) track('outbound_click', target, placement);
+          return;
+        }
+
+        const target = safeInternalTarget(link.href);
+        if (target && target !== location.pathname) {
+          track('navigation', target, placement);
         }
       });
 

--- a/src/lib/track.ts
+++ b/src/lib/track.ts
@@ -1,4 +1,4 @@
-// cookieless event ping. nothing is stored or read on the visitor's device,
+// Cookieless event ping. Nothing is stored in or read from browser storage,
 // so this stays outside ePrivacy consent territory. the server keeps no raw
 // ips, only a daily-rotating hash and a cloudflare-resolved country code
 const EVENTS_API = import.meta.env.PUBLIC_EVENTS_API_URL || '/api/events';
@@ -8,8 +8,11 @@ type EventKind =
   | 'chat_open'
   | 'game_open'
   | 'outbound_click'
+  | 'navigation'
   | 'form_submit'
   | 'not_found';
+
+type LinkPlacement = 'header' | 'footer' | 'content' | 'cta';
 
 function optedOut(): boolean {
   const nav = navigator as Navigator & { globalPrivacyControl?: boolean };
@@ -25,25 +28,65 @@ function screenClass(): string {
 // campaign tag when the current url carries one (utm_source or ref)
 function campaignSource(): string | null {
   const params = new URLSearchParams(location.search);
-  return params.get('utm_source') || params.get('ref');
+  const source = (params.get('utm_source') || params.get('ref'))
+    ?.trim()
+    .toLowerCase();
+  return source && /^[a-z0-9_-]{1,64}$/.test(source) ? source : null;
 }
 
-// target is what was acted on: destination url for outbound_click, game id
-// for game_open
-export function track(kind: EventKind, target?: string) {
+function externalReferrer(): string | null {
+  if (!document.referrer) return null;
+  try {
+    const url = new URL(document.referrer);
+    return url.origin !== location.origin ? url.origin : null;
+  } catch {
+    return null;
+  }
+}
+
+// Keep the destination and path, but never query data or fragments.
+export function safeOutboundTarget(href: string): string | null {
+  try {
+    const url = new URL(href, location.href);
+    if (url.protocol === 'mailto:') return 'email';
+    if (!['http:', 'https:'].includes(url.protocol)) return null;
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return null;
+  }
+}
+
+// Internal transition destinations are paths only.
+export function safeInternalTarget(href: string): string | null {
+  try {
+    const url = new URL(href, location.href);
+    return url.origin === location.origin ? url.pathname : null;
+  } catch {
+    return null;
+  }
+}
+
+export function linkPlacement(link: HTMLAnchorElement): LinkPlacement {
+  const placement = link.closest<HTMLElement>('[data-analytics-placement]')
+    ?.dataset.analyticsPlacement;
+  return placement === 'header' || placement === 'footer' || placement === 'cta'
+    ? placement
+    : 'content';
+}
+
+// target is what was acted on: destination URL/path for link events, game id
+// for game_open. No browser state or identifier is created.
+export function track(
+  kind: EventKind,
+  target?: string,
+  placement?: LinkPlacement,
+) {
   if (!import.meta.env.PROD || optedOut()) return;
 
-  // only external referrers are interesting, internal navigation is noise
-  let referrer: string | null = null;
-  if (kind === 'pageview' && document.referrer) {
-    try {
-      if (new URL(document.referrer).origin !== location.origin) {
-        referrer = document.referrer;
-      }
-    } catch {
-      // unparseable referrer, skip it
-    }
-  }
+  // Internal transitions are click aggregates, never a per-person trail.
+  const referrer = kind === 'pageview' ? externalReferrer() : null;
+  const attribution =
+    kind === 'pageview' ? (referrer ? 'external' : 'direct') : null;
 
   fetch(EVENTS_API, {
     method: 'POST',
@@ -53,6 +96,8 @@ export function track(kind: EventKind, target?: string) {
       path: location.pathname,
       referrer,
       target: target ?? null,
+      placement: placement ?? null,
+      attribution,
       source: kind === 'pageview' ? campaignSource() : null,
       screen: screenClass(),
     }),

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -46,12 +46,14 @@ const secondPost = posts[1];
       <div class="flex gap-3">
         <a
           href="/projects"
+          data-analytics-placement="cta"
           class="bg-fox text-heading font-semibold text-sm px-5 py-2.5 rounded-lg hover:brightness-110 transition-all"
         >
           view projects
         </a>
         <a
           href="/blog"
+          data-analytics-placement="cta"
           class="border border-border text-muted font-medium text-sm px-5 py-2.5 rounded-lg hover:text-heading hover:border-muted transition-colors"
         >
           read blog


### PR DESCRIPTION
## Summary
- preserves the portfolio as the no-cookie, no-browser-storage reference implementation
- strips query strings/fragments and minimizes referrer, outbound, and campaign dimensions on client and server
- moves DNT/GPC handling ahead of analytics rate limiting
- adds daily-hash rotation tests and cross-app aggregate dashboard guidance

## Verification
- Cargo tests: 13 passed
- Astro check: 0 errors and 0 warnings
- Prettier check passed
- production build passed
- git diff --check passed

## Architecture
Raw analytics stays inside each app. A future Grafana/Metabase view should consume aggregate metrics only, with no shared person identifier.