### PR TITLE
docs: correct Pimp My Type YouTube handle

### DIFF
--- a/src/data/people.ts
+++ b/src/data/people.ts
@@ -151,7 +151,7 @@ const rawPeople: RawPerson[] = [
     links: {
       primary: 'https://pimpmytype.com/',
       website: 'https://pimpmytype.com/',
-      youtube: 'https://www.youtube.com/@pimpmytpe',
+      youtube: 'https://www.youtube.com/@pimpmytype',
     },
     summary:
       'Oliver Schöndorfer teaching practical web and UI typography for better UX',


### PR DESCRIPTION
## Repo-agent validation

- **Lane:** docs
- **Goal:** Correct the broken Pimp My Type YouTube handle in the people directory.
- **Base branch:** main
- **Source:** automated link probe (old handle returned 404; corrected handle returned HTTP 200)
- **Risk:** low
- **Changed files:** `src/data/people.ts`
- **Checks:** `pnpm run typecheck` (pass), `pnpm run lint` (pass), `git diff --check` (pass)
- **Known limitation:** `pnpm run check` remains blocked by three pre-existing formatting findings in `.github/dependabot.yml`, `README.md`, and `src/content/blog/homelab-data-recovery.md`; none are part of this PR.
- **Status:** awaiting maintainer review/merge
