### PR TITLE
Add gallery empty state

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -28,6 +28,7 @@ const navLinks = [
   { href: '/projects', label: 'projects' },
   { href: '/people', label: 'people' },
   { href: '/games', label: 'games' },
+  { href: '/gallery', label: 'gallery' },
   { href: '/blog', label: 'blog' },
   { href: '/cv', label: 'cv' },
 ];

--- a/src/pages/gallery.astro
+++ b/src/pages/gallery.astro
@@ -1,0 +1,23 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout
+  title="Gallery | Semyon Fox"
+  description="A curated visual notebook is being assembled."
+>
+  <section class="pt-20 pb-16 md:pt-28">
+    <div class="mb-10">
+      <p class="type-kicker mb-4">field notes</p>
+      <h1 class="type-page-title mb-4">Gallery</h1>
+      <p class="type-body max-w-2xl">
+        A small, selective collection is being assembled.
+      </p>
+    </div>
+
+    <div class="gallery-empty border-t border-heading/[0.08] pt-6">
+      <p class="type-section-title mb-3">Gallery in progress</p>
+      <p class="type-body max-w-xl">No images are published here yet.</p>
+    </div>
+  </section>
+</Layout>

--- a/src/pages/gallery.md.ts
+++ b/src/pages/gallery.md.ts
@@ -1,0 +1,15 @@
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = async () => {
+  const md = `# Gallery
+
+A curated gallery is being assembled. No images are published yet.
+`;
+
+  return new Response(md, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'x-markdown-tokens': String(Math.ceil(md.length / 4)),
+    },
+  });
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -205,6 +205,18 @@ const secondPost = posts[1];
           play
         </p>
       </a>
+
+      <a
+        href="/gallery"
+        class="md:col-span-1 bg-surface border border-heading/[0.06] rounded-bento p-4 flex flex-col items-center justify-center text-center hover:border-heading/10 transition-colors group"
+      >
+        <span class="text-lg font-black text-dim/40 mb-1">~/photos</span>
+        <p
+          class="text-muted text-xs group-hover:text-heading transition-colors"
+        >
+          field notes
+        </p>
+      </a>
     </div>
   </section>
 

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -48,6 +48,7 @@ Stack: ${featured.data.tags.join(', ')}${featured.data.github && !featured.data.
 - [/projects](https://semyon.ie/projects) — ${projects.length} projects
 - [/blog](https://semyon.ie/blog) — ${posts.length} posts
 - [/games](https://semyon.ie/games) — ${games.length} games
+- [/gallery](https://semyon.ie/gallery) — gallery placeholder; no images published yet
 - [/cv](https://semyon.ie/cv) — full CV (PDF at /cv.pdf)
 - [/docs/chat-api](https://semyon.ie/docs/chat-api) — POST /api/chat (site assistant endpoint)
 


### PR DESCRIPTION
## Summary
- add an empty Gallery route and navigation entry
- expose the placeholder through the Markdown route
- include no gallery media files

## Validation
- pnpm check
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Gallery page accessible from desktop and mobile navigation.
  * Added a homepage card linking to the Gallery.
  * Added introductory content and an empty-state message while images are being assembled.
  * Added a Markdown endpoint for the Gallery placeholder content.
  * Included the Gallery in the site’s page listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->